### PR TITLE
Add @electron/remote as replacement for removed remote module

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This project is a fork of Facebook's [@jest-runner/electron](https://github.com/
 ## Debugging
 Normally jest-electron-runner runs a headless instance of electron when testing the renderer process. You may show the UI by adding this to your test:
 ```js
-require('electron').remote.getCurrentWindow().show();
+require('@electron/remote').getCurrentWindow().show();
 ```
 
 ## Tips

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "29.1.1",
             "license": "MIT",
             "dependencies": {
+                "@electron/remote": "^2.0.8",
                 "@jest/console": "^29.3.1",
                 "@jest/transform": "^29.3.1",
                 "electron": "^21.3.1",
@@ -976,6 +977,14 @@
             "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
             "engines": {
                 "node": ">= 4.0.0"
+            }
+        },
+        "node_modules/@electron/remote": {
+            "version": "2.0.8",
+            "resolved": "https://registry.npmjs.org/@electron/remote/-/remote-2.0.8.tgz",
+            "integrity": "sha512-P10v3+iFCIvEPeYzTWWGwwHmqWnjoh8RYnbtZAb3RlQefy4guagzIwcWtfftABIfm6JJTNQf4WPSKWZOpLmHXw==",
+            "peerDependencies": {
+                "electron": ">= 13.0.0"
             }
         },
         "node_modules/@eslint/eslintrc": {

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
         "typescript": "4.9.3"
     },
     "dependencies": {
+        "@electron/remote": "^2.0.8",
         "@jest/console": "^29.3.1",
         "@jest/transform": "^29.3.1",
         "electron": "^21.3.1",

--- a/src/main/electron/electron_process_injected_code.ts
+++ b/src/main/electron/electron_process_injected_code.ts
@@ -37,6 +37,8 @@ app.on("ready", async () => {
         // we spin up an electron process for each test on the main process
         // which pops up an icon for each on macOs. Hiding them is less intrusive
         app.dock?.hide();
+    } else {
+        (await import("@electron/remote/main")).initialize();
     }
 
     const rpcConnection = new RPCConnection(JestWorkerRPC);

--- a/src/main/electron/rpc/JestWorkerRPC.ts
+++ b/src/main/electron/rpc/JestWorkerRPC.ts
@@ -5,6 +5,7 @@
  * See LICENSE.md for licensing information.
  */
 
+import { enable as enableRemote } from "@electron/remote/main";
 import type { TestResult } from "@jest/test-result";
 import { BrowserWindow, ipcMain } from "electron";
 
@@ -44,6 +45,8 @@ async function runInBrowserWindow(testData: IPCTestData): Promise<TestResult> {
                 contextIsolation: false
             }
         });
+        enableRemote(win.webContents);
+
         win.on("close", event => {
             // Prevent closing the window because this breaks the test runner
             event.preventDefault();

--- a/src/test/renderer/window.test.ts
+++ b/src/test/renderer/window.test.ts
@@ -11,4 +11,8 @@ describe("Tests in renderer process", () => {
         // This will freeze Jest when test fails, even the test timeout doesn't trigger.
         window.close();
     });
+    it("can use remote module", async () => {
+        const currentWindow = (await import("@electron/remote")).getCurrentWindow();
+        expect(currentWindow).toHaveProperty("show");
+    });
 });


### PR DESCRIPTION
This pull request adds the remote module through `@electron/remote`, replacing the remote module which is no longer included in electron.

Replaces #9, using ES modules instead of incompatible CommonJS `require()`. I also added tests and updated the README.

Fixes #8.